### PR TITLE
Fix error in archives.blade.php

### DIFF
--- a/src/views/partials/archives.blade.php
+++ b/src/views/partials/archives.blade.php
@@ -5,7 +5,7 @@
 				<ul>
 					@foreach ($months as $monthNumber => $month)
 						<li class="archives--month{{ isset($selectedYear) && $year == $selectedYear && isset($selectedMonth) && $monthNumber == $selectedMonth ? ' archives--month__active' : '' }}">
-							<a href="{{ action('Fbf\LaravelBlog\PostsController@index', array('year' => $year, 'month' => $monthNumber)) }}">
+							<a href="{{ action('Fbf\LaravelBlog\PostsController@indexByYearMonth', array('year' => $year, 'month' => $monthNumber)) }}">
 								{{ $month['monthname'] }} ({{ $month['count'] }})
 							</a>
 						</li>


### PR DESCRIPTION
Archives don't work properly because we have to change "index" action by "indexByYearMonth" action

So we get:

``` php
<a href="{{ action('Fbf\LaravelBlog\PostsController@indexByYearMonth', array('year' => $year, 'month' => $monthNumber)) }}">
```

instead of:

``` php
<a href="{{ action('Fbf\LaravelBlog\PostsController@index', array('year' => $year, 'month' => $monthNumber)) }}">
```
