### PR TITLE
Update view.blade.php (Proposition)

### DIFF
--- a/src/views/posts/view.blade.php
+++ b/src/views/posts/view.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.master')
 
 @section('title')
-	{{ $post->page_title }}
+	{{ !empty($post->page_title) ? $post->page_title : 'Blog &middot; '.$post->title }}
 @endsection
 
 @section('meta_description')


### PR DESCRIPTION
I think it will be better to not force the user to provide a page title, because we can also use the title for most situations.

So something like:

``` php
@section('title')
 {{ !empty($post->page_title) ? $post->page_title : 'Blog &middot; '.$post->title }}
@endsection 
```

instead of:

``` php
@section('title')
 {{ $post->page_title }}
@endsection 
```

should be appreciate :)
