### PR TITLE
Fix mistake: duplicate meta_description

### DIFF
--- a/src/config/administrator/posts.php
+++ b/src/config/administrator/posts.php
@@ -121,7 +121,7 @@ return array(
 			'title' => 'In RSS Feed?',
 			'type' => 'bool',
 		),
-		'meta_description' => array(
+		'page_title' => array(
 			'title' => 'Page Title',
 			'type' => 'text',
 		),


### PR DESCRIPTION
Just change **meta_description** by **page_title** due to some duplication issue
