### PR TITLE
Update to fzaninotto/Faker 1.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/support": "4.*",
         "thujohn/rss": "dev-master",
         "cviebrock/eloquent-sluggable": "1.0.*",
-        "fzaninotto/faker": "1.3.*"
+        "fzaninotto/faker": "1.4.*"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Just what the title says :)

Other packages have upgraded and when trying to use both, Composer can't resolve the dependencies, of course.

Either that or, if the seeding (where Faker is used) is only meant for testing, then move the dependency to `require-dev` instead of `require`.
