### PR TITLE
Allow custom attributes in images breaking in PHP 5.3

### DIFF
--- a/src/models/Post.php
+++ b/src/models/Post.php
@@ -125,7 +125,7 @@ class Post extends \Eloquent {
 	 * @param $size
 	 * @return null|string
 	 */
-	public function getImage($type, $size, array $attributes = [])
+	public function getImage($type, $size, array $attributes = array())
 	{
 		if (empty($this->$type))
 		{


### PR DESCRIPTION
In the commit https://github.com/FbF/Laravel-Blog/commit/462d6b3e3942c7d9dbd57aa90529be15fb734b40 a new parameter is added to the function getImage() in src/models/Post.php. This parameter has the default of [] which is the shorthand for an array as introduced in PHP 5.4.

Since Laravel < 4.2 is designed for PHP 5.3 upwards this means that in environments where your package is being used on PHP 5.3 the user is forced to use version 0.7.

Since this is such a small detail I have done a pull request changing the shorthand array into array(). Though I also understand that maybe you want to force users to update, in which case it might be good to change the composer.json to require PHP 5.4 for versions above 0.7.

I hope this is detailed enough, first pull request :D
