### PR TITLE
Restore thujohn/rss package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.*",
-        "thujohn/rss-l4": "dev-master",
+        "thujohn/rss": "dev-master",
         "cviebrock/eloquent-sluggable": "1.0.*",
         "fzaninotto/faker": "1.4.*"
     },


### PR DESCRIPTION
[thujohn/rss's composer.json](https://github.com/thujohn/rss-l4/blob/master/composer.json) clearly shows the package name as `thujohn/rss` and not `thujohn/rss-l4`. This should fix #24
