### PR TITLE
Call missing parent constructor in PostsController

### DIFF
--- a/src/controllers/PostsController.php
+++ b/src/controllers/PostsController.php
@@ -12,6 +12,7 @@ class PostsController extends \BaseController {
 	 */
 	public function __construct(Post $post)
 	{
+		parent::__construct();
 		$this->post = $post;
 	}
 


### PR DESCRIPTION
PostsController derives from BaseController but currently the constructor does not call the parent's constructor, which means any code you have in your BaseController constructor will not be executed.
